### PR TITLE
fix/MissingKotlinParameterException

### DIFF
--- a/lib/src/main/kotlin/be/zvz/alsong/dto/LyricInfo.kt
+++ b/lib/src/main/kotlin/be/zvz/alsong/dto/LyricInfo.kt
@@ -18,7 +18,7 @@ data class LyricInfo(
     val registerFirstUrl: String,
     val registerPhone: String,
     val artistName: String,
-    val registerFirstPhone: String,
+    val registerFirstPhone: String?,
     val titleName: String,
     val registerFirstComment: String,
     val registerEmail: String

--- a/lib/src/main/kotlin/be/zvz/alsong/dto/LyricLookup.kt
+++ b/lib/src/main/kotlin/be/zvz/alsong/dto/LyricLookup.kt
@@ -21,7 +21,7 @@ data class LyricLookup(
     val registerFirstUrl: String,
     val registDate: String,
     val registerPhone: String,
-    val registerFirstPhone: String,
+    val registerFirstPhone: String?,
     val artist: String,
     val title: String,
     val registerFirstComment: String,


### PR DESCRIPTION
# Fix

Instantiation of [simple type, class `be.zvz.alsong.dto.LyricInfo`] value failed for JSON property `register_first_phone` due to missing (therefore NULL) value for creator parameter `registerFirstPhone` which is a non-nullable type